### PR TITLE
Align load_balancer_sku and public_ip_sku

### DIFF
--- a/terraform/nginx.tf
+++ b/terraform/nginx.tf
@@ -18,6 +18,7 @@ resource "azurerm_public_ip" "nginx_ingress" {
   location                     = azurerm_kubernetes_cluster.akstf.location
   resource_group_name          = azurerm_kubernetes_cluster.akstf.node_resource_group
   allocation_method            = "Static"
+  sku                          = "Standard"
   domain_name_label            = var.dns_prefix
 
   depends_on = [azurerm_kubernetes_cluster.akstf]


### PR DESCRIPTION
Because load_balancer_sku is "standard", the public IP needs also to be standard:
```
Code="PublicIPAndLBSkuDoNotMatch" Message="Standard sku load balancer /subscriptions/-/resourceGroups/-/providers/Microsoft.Network/loadBalancers/kubernetes cannot reference Basic sku publicIP /subscriptions/-/resourceGroups/-/providers/Microsoft.Network/publicIPAddresses/nginx-ingress-pip.
```